### PR TITLE
:art: Enable supporting MongoDB 4+ versions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 13.5.3
+  chef_version: 14.0.210
   privileged: true
 
 provisioner:
@@ -16,20 +16,19 @@ verifier:
   # output: reports/%{platform}_%{suite}_inspec.xml
 
 platforms:
-  - name: debian-8
+  - name: debian-9
     driver:
-      image: dokken/debian-8
+      image: dokken/debian-9
       pid_one_command: /bin/systemd
     run_list:
       - recipe[apt]
 
-  # Mongodb not ready yet for the debian-9
-  # - name: debian-9
-  #   driver:
-  #     image: dokken/debian-9
-  #     pid_one_command: /bin/systemd
-  #   run_list:
-  #     - recipe[apt]
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+    run_list:
+      - recipe[apt]
 
   - name: ubuntu-16
     driver:
@@ -37,14 +36,6 @@ platforms:
       pid_one_command: /bin/systemd
     run_list:
       - recipe[apt]
-
-  # Mongodb not ready yet for the ubuntu-17
-  # - name: ubuntu-17
-  #   driver:
-  #     image: dokken/ubuntu-17.04
-  #     pid_one_command: /bin/systemd
-  #   run_list:
-  #     - recipe[apt]
 
   - name: centos-7
     driver:
@@ -54,41 +45,6 @@ platforms:
       - recipe[yum]
 
 suites:
-  - name: 32x
-    excludes:
-      - debian-9
-      - centos-7
-    verifier:
-      inspec_tests:
-        - path: test/inspec/cluster
-        - path: test/inspec/packages
-      attributes:
-        mongodb_package_version: 3.2.19
-    run_list:
-      - recipe[mongodb-lib-test::default]
-      - recipe[mongodb-lib-test::replicaset_builder]
-      - recipe[mongodb-lib-test::shard_builder]
-    attributes:
-      mongodb:
-        lib:
-          version: 3.2.19
-
-  - name: 34x
-    run_list:
-      - recipe[mongodb-lib-test::default]
-      - recipe[mongodb-lib-test::replicaset_builder]
-      - recipe[mongodb-lib-test::shard_builder]
-    verifier:
-      inspec_tests:
-        - path: test/inspec/cluster
-        - path: test/inspec/packages
-      attributes:
-        mongodb_package_version: 3.4.13
-    attributes:
-      mongodb:
-        lib:
-          version: 3.4.13
-
   - name: 36x
     run_list:
       - recipe[mongodb-lib-test::default]
@@ -99,8 +55,40 @@ suites:
         - path: test/inspec/cluster
         - path: test/inspec/packages
       attributes:
-        mongodb_package_version: 3.6.3
+        mongodb_package_version: 3.6.17
     attributes:
       mongodb:
         lib:
-          version: 3.6.3
+          version: 3.6.17
+
+  - name: 40x
+    run_list:
+      - recipe[mongodb-lib-test::default]
+      - recipe[mongodb-lib-test::replicaset_builder]
+      - recipe[mongodb-lib-test::shard_builder]
+    verifier:
+      inspec_tests:
+        - path: test/inspec/cluster
+        - path: test/inspec/packages
+      attributes:
+        mongodb_package_version: 4.0.16
+    attributes:
+      mongodb:
+        lib:
+          version: 4.0.16
+
+  - name: 42x
+    run_list:
+      - recipe[mongodb-lib-test::default]
+      - recipe[mongodb-lib-test::replicaset_builder]
+      - recipe[mongodb-lib-test::shard_builder]
+    verifier:
+      inspec_tests:
+        - path: test/inspec/cluster
+        - path: test/inspec/packages
+      attributes:
+        mongodb_package_version: 4.2.2
+    attributes:
+      mongodb:
+        lib:
+          version: 4.2.2

--- a/libraries/mongodb_repo_apt.rb
+++ b/libraries/mongodb_repo_apt.rb
@@ -18,12 +18,12 @@ module MongoDBLibCookbook
 
     def default_key
       case version
-      when '3.2'
-        'EA312927'
-      when '3.4'
-        '0C49F3730359A14518585931BC711F9BA15703C6'
       when '3.6'
         '2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5'
+      when '4.0'
+        '9DA31620334BD75D9DCB49F368818C72E52529D4'
+      when '4.2'
+        '4B7C549A058F8B6B'
       else
         'UNSUPPORTED VERSION KEY'
       end


### PR DESCRIPTION
1) Delete not supported version of MongoDB
2) Add MongoDB 4.0, Debian 10
3) Update Chef version